### PR TITLE
Use ffmpeg.js for valid audio chunks

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@ffmpeg/ffmpeg": "^0.12.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -20,9 +20,9 @@ export const transcribeAudio = async (
     if (onProgressUpdate) onProgressUpdate(5, 'Verarbeite Audiodatei...');
     const processedFile = await processAudioFile(file);
     
-    // Teile die Datei in kleinere Stücke, wenn sie zu groß ist (max. 25MB pro Stück für OpenAI API)
+    // Teile die Datei in kleinere Stücke, falls sie zu groß ist
     if (onProgressUpdate) onProgressUpdate(10, 'Teile Datei in Chunks...');
-    const audioChunks = await splitAudioFile(processedFile, 24);
+    const audioChunks = await splitAudioFile(processedFile);
     
     console.log(`Datei in ${audioChunks.length} Teile aufgeteilt`);
     
@@ -72,9 +72,9 @@ const transcribeChunk = async (audioChunk: Blob, apiKey: string, retries = 3): P
       const formData = new FormData();
       
       // Konvertiere Blob zu File, wenn es ein Blob ist
-      const chunkFile = audioChunk instanceof File 
-        ? audioChunk 
-        : new File([audioChunk], 'chunk.webm', { type: audioChunk.type });
+      const chunkFile = audioChunk instanceof File
+        ? audioChunk
+        : new File([audioChunk], 'chunk.mp3', { type: audioChunk.type });
       
       formData.append('file', chunkFile);
       formData.append('model', 'whisper-1');

--- a/src/utils/audioUtils.ts
+++ b/src/utils/audioUtils.ts
@@ -3,6 +3,19 @@
  * Audio-Verarbeitungsutilitäten für die Transkription großer Dateien
  */
 
+import { createFFmpeg, fetchFile } from '@ffmpeg/ffmpeg';
+
+// Globale Instanz von ffmpeg, um wiederholtes Laden zu vermeiden
+const ffmpeg = createFFmpeg({ log: false });
+let ffmpegLoaded = false;
+
+const loadFFmpeg = async () => {
+  if (!ffmpegLoaded) {
+    await ffmpeg.load();
+    ffmpegLoaded = true;
+  }
+};
+
 /**
  * Teilt eine große Audiodatei in kleinere Chunks für die API-Verarbeitung
  * @param file Die zu teilende Audiodatei
@@ -11,38 +24,45 @@
  */
 export const splitAudioFile = async (
   file: File,
-  maxSizeInMB: number = 24
+  maxDurationSec: number = 600 // ca. 10 Minuten pro Chunk
 ): Promise<Blob[]> => {
-  // Wenn die Datei bereits klein genug ist, direkt zurückgeben
-  if (file.size <= maxSizeInMB * 1024 * 1024) {
+  // Für kleine Dateien keine Aufteilung nötig
+  if (file.size <= 25 * 1024 * 1024) {
     return [file];
   }
 
-  // Fortgeschrittene Audioverarbeitung für sehr große Dateien
-  console.log(`Teile große Datei (${Math.round(file.size / (1024 * 1024))} MB) in ${maxSizeInMB}MB-Chunks`);
-  
-  try {
-    const arrayBuffer = await file.arrayBuffer();
-    const chunkSize = maxSizeInMB * 1024 * 1024;
-    const chunks: Blob[] = [];
-    
-    // Teile die Datei in Stücke der maximalen Größe
-    for (let i = 0; i < arrayBuffer.byteLength; i += chunkSize) {
-      const chunk = arrayBuffer.slice(i, Math.min(i + chunkSize, arrayBuffer.byteLength));
-      chunks.push(new Blob([chunk], { type: file.type }));
-      
-      // Gib Speicher frei, um Out-of-Memory-Fehler zu vermeiden
-      if (i % (10 * chunkSize) === 0 && i > 0) {
-        await new Promise(resolve => setTimeout(resolve, 100));
-      }
+  console.log(`Teile große Datei (${Math.round(file.size / (1024 * 1024))} MB) in zeitbasierte Chunks`);
+
+  await loadFFmpeg();
+
+  ffmpeg.FS('writeFile', 'input.mp3', await fetchFile(file));
+
+  await ffmpeg.run(
+    '-i', 'input.mp3',
+    '-f', 'segment',
+    '-segment_time', String(maxDurationSec),
+    '-c', 'copy',
+    'chunk_%03d.mp3'
+  );
+
+  const chunks: Blob[] = [];
+  let index = 0;
+  while (true) {
+    const name = `chunk_${index.toString().padStart(3, '0')}.mp3`;
+    try {
+      const data = ffmpeg.FS('readFile', name);
+      chunks.push(new File([data.buffer], name, { type: 'audio/mpeg' }));
+      ffmpeg.FS('unlink', name);
+      index++;
+    } catch {
+      break;
     }
-    
-    console.log(`Erfolgreich in ${chunks.length} Chunks aufgeteilt`);
-    return chunks;
-  } catch (error) {
-    console.error('Fehler beim Aufteilen der Audiodatei:', error);
-    throw new Error('Die Audiodatei konnte nicht verarbeitet werden. Bitte versuchen Sie eine kleinere Datei oder ein anderes Format.');
   }
+
+  ffmpeg.FS('unlink', 'input.mp3');
+
+  console.log(`Erfolgreich in ${chunks.length} Chunks aufgeteilt`);
+  return chunks.length > 0 ? chunks : [file];
 };
 
 /**
@@ -61,17 +81,25 @@ export const estimateProcessingTime = (fileSizeInMB: number): number => {
  * das von der Whisper API besser unterstützt wird (falls nötig)
  */
 export const processAudioFile = async (file: File): Promise<File> => {
-  // Die Whisper API unterstützt WEBM-Dateien nativ, daher ist keine Konvertierung erforderlich
-  // In einer vollständigen Produktionsimplementierung könnte hier eine Qualitätsoptimierung oder
-  // Formatkonvertierung stattfinden, falls bestimmte WEBM-Codecs nicht optimal unterstützt werden
-  
-  // Überprüfe auf extrem große Dateien und warne den Benutzer
   const fileSizeInMB = file.size / (1024 * 1024);
   if (fileSizeInMB > 500) {
     console.warn(`Sehr große Datei (${Math.round(fileSizeInMB)} MB) - Die Verarbeitung kann einige Zeit dauern`);
   }
-  
-  return file;
+
+  if (file.type === 'audio/mpeg' || file.name.toLowerCase().endsWith('.mp3')) {
+    return file;
+  }
+
+  await loadFFmpeg();
+
+  ffmpeg.FS('writeFile', 'input', await fetchFile(file));
+  await ffmpeg.run('-i', 'input', '-ar', '44100', 'output.mp3');
+  const data = ffmpeg.FS('readFile', 'output.mp3');
+
+  ffmpeg.FS('unlink', 'input');
+  ffmpeg.FS('unlink', 'output.mp3');
+
+  return new File([data.buffer], file.name.replace(/\.[^/.]+$/, '.mp3'), { type: 'audio/mpeg' });
 };
 
 /**


### PR DESCRIPTION
## Summary
- convert uploaded audio to mp3 using `@ffmpeg/ffmpeg`
- split large mp3 files into 10‑minute chunks via ffmpeg
- send mp3 chunks to OpenAI

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: missing @eslint/js)*
